### PR TITLE
chore(CI): Skip redundant `gradle check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,3 @@ jobs:
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: build
-      - uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: check


### PR DESCRIPTION
Since we're already running `gradle build`, which runs `gradle check`.
