### PR TITLE
fix(CogRPC Server): Allow non-HTTP2 TLS connections

### DIFF
--- a/app/src/main/java/tech/relaycorp/cogrpc/server/ClientsConnectedFilter.kt
+++ b/app/src/main/java/tech/relaycorp/cogrpc/server/ClientsConnectedFilter.kt
@@ -20,8 +20,11 @@ class ClientsConnectedFilter : ServerTransportFilter() {
         return super.transportReady(transportAttrs)
     }
 
-    override fun transportTerminated(transportAttrs: Attributes) {
-        transportAttrs.calledIpAddress?.let {
+    override fun transportTerminated(transportAttrs: Attributes?) {
+        // transportAttrs == null when the incoming TLS connection is not HTTP2. This can be the
+        // case with JS gRPC clients employing this workaround:
+        // https://github.com/grpc/grpc-node/issues/663#issuecomment-624000152
+        transportAttrs?.calledIpAddress?.let {
             clients.sendBlocking(clients.value - it)
         }
         super.transportTerminated(transportAttrs)


### PR DESCRIPTION
The [Node.js gRPC client has a bug](https://github.com/grpc/grpc-node/issues/663) that requires downloading the TLS certificate before initiating the gRPC connection [as a workaround](https://github.com/grpc/grpc-node/issues/663#issuecomment-624000152). When that's done, `transportAttrs` is `null` (a behaviour that's undocumented), so it led to unhandled exceptions.

Here's how I reproduced it locally:

```
openssl s_client -connect 192.168.43.1:21473 -showcerts
```