### PR TITLE
fix(Build): Use latest NDK version to fix broken build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ repositories {
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
-    ndkVersion '21.0.6113669'
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "tech.relaycorp.courier"

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <lint>
-    <issue id="NewerVersionAvailable" severity="ignore">
-        <!-- We're using dependabot to keep dependencies up-to-date -->
-    </issue>
+    <!-- We're using dependabot to keep dependencies up-to-date -->
+    <issue id="NewerVersionAvailable" severity="ignore"/>
+    <issue id="GradleDependency" severity="ignore"/>
+
     <issue id="InvalidPackage">
         <!-- Ignore errors about BC importing javax.naming because we don't use those modules -->
         <ignore path="**/bcpkix-*.jar" />


### PR DESCRIPTION
This is a workaround for gradle/gradle#12440. I thought this was the least bad workaround but happy to use another workaround -- Ideally dependabot would upgrade it but it can't because it's not an actual Gradle dependency.
