### PR TITLE
fix: Downgrade gRPC libraries to work around breaking change

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,12 @@ update_configs:
   - package_manager: "java:gradle"
     directory: "/"
     update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          # See: https://github.com/relaycorp/relaynet-courier-android/issues/231
+          dependency_name: "io.grpc:grpc-*"
+          version_requirement: "1.x"
+
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,9 @@ apply from: 'jacoco.gradle'
 
 repositories {
     maven { url 'https://jitpack.io' }
+
+    // TODO: Remove once the CogRPC libs have been approved for inclusion in JCenter
+    maven { url  "https://dl.bintray.com/relaycorp/maven" }
 }
 
 android {
@@ -124,8 +127,8 @@ dependencies {
 
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.38.4'
-    implementation 'tech.relaycorp:relaynet-cogrpc:1.1.2'
-    implementation 'tech.relaycorp:relaynet-cogrpc-okhttp:1.1.0'
+    implementation 'tech.relaycorp:cogrpc:1.1.5'
+    implementation 'tech.relaycorp:cogrpc-okhttp:1.1.3'
 
     // ORM
     def room_version = "2.2.5"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,9 +23,6 @@ apply from: 'jacoco.gradle'
 
 repositories {
     maven { url 'https://jitpack.io' }
-
-    // TODO: Remove once the CogRPC libs have been approved for inclusion in JCenter
-    maven { url  "https://dl.bintray.com/relaycorp/maven" }
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,8 +124,8 @@ dependencies {
 
     // Relaynet
     implementation 'tech.relaycorp:relaynet:1.38.4'
-    implementation 'tech.relaycorp:cogrpc:1.1.5'
-    implementation 'tech.relaycorp:cogrpc-okhttp:1.1.3'
+    implementation 'tech.relaycorp:cogrpc:1.1.6'
+    implementation 'tech.relaycorp:cogrpc-okhttp:1.1.4'
 
     // ORM
     def room_version = "2.2.5"


### PR DESCRIPTION
See: https://github.com/relaycorp/relaynet-courier-android/issues/231

Also use CogRPC libs by their new names.

