### PR TITLE
fix(CogRPC): Increase metadata size to allow CCAs with CCRs

### DIFF
--- a/app/src/androidTest/java/tech/relaycorp/courier/ui/settings/SettingsActivityTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/courier/ui/settings/SettingsActivityTest.kt
@@ -4,6 +4,7 @@ import com.google.android.material.slider.Slider
 import com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertDisabled
 import com.schibsted.spain.barista.assertion.BaristaEnabledAssertions.assertEnabled
 import com.schibsted.spain.barista.assertion.BaristaVisibilityAssertions.assertContains
+import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -14,7 +15,7 @@ import tech.relaycorp.courier.R
 import tech.relaycorp.courier.data.database.StoredMessageDao
 import tech.relaycorp.courier.data.preference.StoragePreferences
 import tech.relaycorp.courier.test.BaseActivityTestRule
-import tech.relaycorp.courier.test.WaitAssertions.waitForAssertEquals
+import tech.relaycorp.courier.test.WaitAssertions.suspendWaitFor
 import tech.relaycorp.courier.test.appComponent
 import tech.relaycorp.courier.test.factory.StoredMessageFactory
 import javax.inject.Inject
@@ -62,14 +63,14 @@ class SettingsActivityTest {
     fun setMaxStorageToMinimum() {
         val activity = testRule.start()
         val slider = activity.findViewById<Slider>(R.id.storageMaxSlider)
-        slider.postDelayed({
-            slider.value = slider.valueFrom
-        }, 500)
         runBlocking {
-            waitForAssertEquals(
-                SettingsViewModel.MIN_STORAGE_SIZE,
-                storagePreferences.getMaxStorageSize()::first
-            )
+            suspendWaitFor {
+                slider.value = slider.valueFrom
+                assertEquals(
+                    SettingsViewModel.MIN_STORAGE_SIZE,
+                    storagePreferences.getMaxStorageSize().first()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/tech/relaycorp/cogrpc/server/CogRPCServer.kt
+++ b/app/src/main/java/tech/relaycorp/cogrpc/server/CogRPCServer.kt
@@ -104,7 +104,7 @@ internal constructor(
 
     companion object {
         private const val MAX_MESSAGE_SIZE = 8_397_056
-        private const val MAX_METADATA_SIZE = 4_000 // ~2.5kib for a base64-encoded CCA + overhead
+        private const val MAX_METADATA_SIZE = 6_000 // ~4.9kib for a base64-encoded CCA + overhead
         private const val MAX_CONCURRENT_CALLS_PER_CONNECTION = 3
         private val MAX_CONNECTION_AGE = 15.minutes
         private val MAX_CONNECTION_AGE_GRACE = 30.seconds


### PR DESCRIPTION
CCAs now include Cargo Collection Requests (CCRs), which in turn contain the authz certificate to be used by public gateways to send data to private gateways.

This is needed for https://github.com/relaycorp/relaynet-gateway-android/issues/222