### PR TITLE
feat(Public sync): Resolve public gateway addresses

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,7 @@ dependencies {
     implementation 'tech.relaycorp:relaynet:1.39.0'
     implementation 'tech.relaycorp:cogrpc:1.1.6'
     implementation 'tech.relaycorp:cogrpc-okhttp:1.1.4'
+    implementation 'tech.relaycorp:doh:1.0.0'
 
     // ORM
     def room_version = "2.2.5"

--- a/app/src/main/java/tech/relaycorp/courier/data/model/MessageAddress.kt
+++ b/app/src/main/java/tech/relaycorp/courier/data/model/MessageAddress.kt
@@ -1,5 +1,10 @@
 package tech.relaycorp.courier.data.model
 
+import tech.relaycorp.doh.DoHClient
+import tech.relaycorp.doh.LookupFailureException
+import java.lang.Exception
+import java.net.URL
+
 sealed class MessageAddress {
 
     val type
@@ -33,5 +38,31 @@ sealed class MessageAddress {
     }
 }
 
-data class PublicMessageAddress(val publicValue: String) : MessageAddress()
+data class PublicMessageAddress(val publicValue: String) : MessageAddress() {
+    @Suppress("BlockingMethodInNonBlockingContext") // Needed for URL()
+    @Throws(PublicAddressResolutionException::class)
+    suspend fun resolve(doHClient: DoHClient): String {
+        val originalURL = URL(publicValue)
+        val srvName = "_rcrc._tcp.${originalURL.host}"
+        val answer = try {
+            doHClient.lookUp(srvName, "SRV")
+        } catch (exc: LookupFailureException) {
+            throw PublicAddressResolutionException("Failed to resolve SRV for ${originalURL.host}", exc)
+        }
+        val srvRecordData = answer.data.first()
+        val recordFields = srvRecordData.split(" ")
+        if (recordFields.size < 4) {
+            throw PublicAddressResolutionException(
+                "Malformed SRV for ${originalURL.host} ($srvRecordData)"
+            )
+        }
+        val targetHost = recordFields[3].trimEnd('.')
+        val targetPort = recordFields[2]
+        return "https://$targetHost:$targetPort"
+    }
+}
+
+class PublicAddressResolutionException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
+
 data class PrivateMessageAddress(val privateValue: String) : MessageAddress()

--- a/app/src/sharedTest/java/tech/relaycorp/courier/test/factory/StoredMessageFactory.kt
+++ b/app/src/sharedTest/java/tech/relaycorp/courier/test/factory/StoredMessageFactory.kt
@@ -9,10 +9,11 @@ import java.util.Date
 import java.util.Random
 
 object StoredMessageFactory {
-    fun build(): StoredMessage {
-        val recipientAddress = MessageAddress.of(Random().nextInt().toString())
+    fun build(
+        recipientAddress: MessageAddress = MessageAddress.of(Random().nextInt().toString())
+    ): StoredMessage {
         return StoredMessage(
-            recipientAddress = MessageAddress.of(Random().nextInt().toString()),
+            recipientAddress = recipientAddress,
             recipientType = recipientAddress.type,
             senderAddress = PrivateMessageAddress(Random().nextInt().toString()),
             messageId = MessageId(Random().nextInt().toString()),

--- a/app/src/test/java/tech/relaycorp/courier/data/model/MessageAddressTest.kt
+++ b/app/src/test/java/tech/relaycorp/courier/data/model/MessageAddressTest.kt
@@ -1,11 +1,20 @@
 package tech.relaycorp.courier.data.model
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tech.relaycorp.doh.Answer
+import tech.relaycorp.doh.DoHClient
+import tech.relaycorp.doh.LookupFailureException
 
 internal class MessageAddressTest {
-
     @Test
     internal fun type() {
         assertEquals(
@@ -18,6 +27,71 @@ internal class MessageAddressTest {
         )
         assertThrows<IllegalArgumentException> {
             MessageAddress.Type.fromValue("invalid")
+        }
+    }
+}
+
+class PublicMessageAddressTest {
+    @Nested
+    inner class Resolve {
+        private val dohClient = mock<DoHClient>()
+
+        private val originalHost = "example.com"
+        private val originalPublicAddress = "https://$originalHost"
+        private val targetHost = "target.example.com"
+        private val targetPort = "1357"
+        private val srvRecordName = "_rcrc._tcp.$originalHost"
+        private val srvRecordData = "0 1 $targetPort $targetHost."
+
+        private val publicAddress = PublicMessageAddress(originalPublicAddress)
+
+        @BeforeEach
+        internal fun setUp() {
+            runBlocking {
+                whenever(dohClient.lookUp(srvRecordName, "SRV")).thenReturn(Answer(listOf(srvRecordData)))
+            }
+        }
+
+        @Test
+        fun `Target host and port should be returned`() = runBlockingTest {
+            val resolvedAddress = publicAddress.resolve(dohClient)
+
+            assertEquals("https://$targetHost:$targetPort", resolvedAddress)
+        }
+
+        @Test
+        fun `Any original scheme, port, path, query string or fragment should be discarded`() = runBlockingTest {
+            val complexPublicAddress =
+                PublicMessageAddress("http://$originalHost:9876/path?query=string#fragment")
+
+            val resolvedAddress = complexPublicAddress.resolve(dohClient)
+
+            assertEquals("https://$targetHost:$targetPort", resolvedAddress)
+        }
+
+        @Test
+        fun `SRV data with fewer than four fields should be refused`() = runBlockingTest {
+            val malformedSRVData = "1 2 3"
+            whenever(dohClient.lookUp(any(), any())).thenReturn(Answer(listOf(malformedSRVData)))
+
+            val exception = assertThrows<PublicAddressResolutionException> {
+                publicAddress.resolve(dohClient)
+            }
+
+            assertEquals("Malformed SRV for $originalHost ($malformedSRVData)", exception.message)
+        }
+
+        @Test
+        fun `Lookup errors should be wrapped`() = runBlockingTest {
+            val lookupException = LookupFailureException("Whoops")
+            whenever(dohClient.lookUp(any(), any())).thenThrow(lookupException)
+
+            val exception = assertThrows<PublicAddressResolutionException> {
+                publicAddress.resolve(dohClient)
+            }
+
+            assertEquals("Failed to resolve SRV for $originalHost", exception.message)
+            assertEquals(lookupException, exception.cause)
         }
     }
 }


### PR DESCRIPTION
This change is needed to allow users of the Android Gateway to view/change their public gateway by providing a unified address across all bindings (PoWeb, PoHTTP, CogRPC).

That is, we'll be able to use public addresses like `frankfurt.relaycorp.cloud` and each client will be able to resolve that to an actual URL that they can use. For example, the CogRPC record for `frankfurt.relaycorp.cloud` currently resolves to `cogrpc-frankfurt.relaycorp.cloud:443`.

This PR depends on https://github.com/relaycorp/relaynet-gateway-android/pull/235