### PR TITLE
fix(public sync): Increase wait time to 10 seconds

### DIFF
--- a/app/src/main/java/tech/relaycorp/courier/domain/PublicSync.kt
+++ b/app/src/main/java/tech/relaycorp/courier/domain/PublicSync.kt
@@ -50,7 +50,7 @@ class PublicSync
     }
 
     companion object {
-        private val WAIT_PERIOD = 2.seconds
+        private val WAIT_PERIOD = 10.seconds
 
         // TODO: Remove this once we can use CloudFlare
         // https://github.com/cloudflare/cloudflare-docs/issues/565


### PR DESCRIPTION
To give plenty of time to the public gateway and public endpoints to reply, should they need to reply to any parcels.

Fixes #256