### PR TITLE
fix(private sync): Allow Android 11+ devices to pick an IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ documentation at this point.
 ## Multiple IP addresses in the private subnet are unsupported
 
 If you've rooted your Android device or flashed it with a custom ROM, you might be able to have 
-multiple IP address in the subnet `192.168.43.0/24`. If that were the case, the courier app will 
+multiple IP address in the subnet `192.168.0.0/16`. If that were the case, the courier app will 
 fail to allow incoming connections from private gateways: We need exactly one IP address in that 
 range so that the app can self-issue TLS certificates for it.
 

--- a/app/firebase-test-lab.yml
+++ b/app/firebase-test-lab.yml
@@ -39,3 +39,9 @@ spec:
       version: 29   # Android 10.0
       locale: en
       orientation: portrait
+
+    # Pixel 2 (virtual)
+    - model: Pixel2
+      version: 30   # Android 11.0
+      locale: en
+      orientation: portrait

--- a/app/src/main/java/tech/relaycorp/cogrpc/server/Networking.kt
+++ b/app/src/main/java/tech/relaycorp/cogrpc/server/Networking.kt
@@ -1,17 +1,18 @@
 package tech.relaycorp.cogrpc.server
 
 import androidx.annotation.VisibleForTesting
+import tech.relaycorp.courier.common.Logging.logger
 import java.net.NetworkInterface
 
 internal object Networking {
     @VisibleForTesting
-    var androidGatewaySubnetPrefix: String? = "192.168.43."
+    var androidGatewaySubnetPrefix: String? = "192.168."
 
     /**
      * Return the local IP address used by the current device in the WiFi hotspot network it created
      *
      * An exception may be thrown in rooted devices or those with a custom version of Android where
-     * the number of local IP addresses in the subnet 192.168.43.0/24 does not equal one.
+     * the number of local IP addresses in the subnet 192.168.0.0/16 does not equal one.
      */
     @Throws(GatewayIPAddressException::class)
     fun getGatewayIpAddress(): String {

--- a/app/src/main/java/tech/relaycorp/cogrpc/server/Networking.kt
+++ b/app/src/main/java/tech/relaycorp/cogrpc/server/Networking.kt
@@ -1,7 +1,6 @@
 package tech.relaycorp.cogrpc.server
 
 import androidx.annotation.VisibleForTesting
-import tech.relaycorp.courier.common.Logging.logger
 import java.net.NetworkInterface
 
 internal object Networking {

--- a/app/src/test/java/tech/relaycorp/cogrpc/server/NetworkingTest.kt
+++ b/app/src/test/java/tech/relaycorp/cogrpc/server/NetworkingTest.kt
@@ -21,7 +21,7 @@ class NetworkingTest {
                 assertThrows<GatewayIPAddressException> { spiedNetworking.getGatewayIpAddress() }
 
             assertEquals(
-                "No address with the prefix 192.168.43. was found",
+                "No address with the prefix 192.168. was found",
                 exception.message
             )
         }
@@ -36,7 +36,7 @@ class NetworkingTest {
                 assertThrows<GatewayIPAddressException> { spiedNetworking.getGatewayIpAddress() }
 
             assertEquals(
-                "Multiple addresses with the prefix 192.168.43. were found",
+                "Multiple addresses with the prefix 192.168. were found",
                 exception.message
             )
         }


### PR DESCRIPTION
Fixes #270