### PR TITLE
chore(CI): Replace devices no longer supported on Firebase Test Lab

### DIFF
--- a/app/firebase-test-lab.yml
+++ b/app/firebase-test-lab.yml
@@ -4,8 +4,8 @@ spec:
   test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
   timeout: 30m
   device:
-    # Huawei ALE-L23 (physical). The oldest device we're testing.
-    - model: hwALE-H
+    # Nexus 4 (virtual)
+    - model: Nexus4
       version: 21   # Android 5.0
       locale: en
       orientation: portrait

--- a/app/firebase-test-lab.yml
+++ b/app/firebase-test-lab.yml
@@ -4,8 +4,8 @@ spec:
   test: app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
   timeout: 30m
   device:
-    # Asus Nexus 7 (physical). The oldest device we're testing.
-    - model: flo
+    # Huawei ALE-L23 (physical). The oldest device we're testing.
+    - model: hwALE-H
       version: 21   # Android 5.0
       locale: en
       orientation: portrait
@@ -28,8 +28,8 @@ spec:
       locale: en
       orientation: portrait
 
-    # Pixel 2 (physical)
-    - model: walleye
+    # LG LM-Q910 (physical)
+    - model: phoenix_sprout
       version: 28   # Android 9.0
       locale: en
       orientation: portrait


### PR DESCRIPTION
Asus Nexus 7 and Pixel 2 are no longer supported, so tests weren't running on Android 5 and 9.
