### PR TITLE
fix: clearButtonDisabledWithData flaky test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -181,9 +181,9 @@ spotless {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions.freeCompilerArgs += [
-            '-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi',
-            '-Xuse-experimental=kotlinx.coroutines.FlowPreview',
-            '-Xuse-experimental=kotlin.time.ExperimentalTime'
+            '-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
+            '-opt-in=kotlinx.coroutines.FlowPreview',
+            '-opt-in=kotlin.time.ExperimentalTime'
     ]
 }
 

--- a/app/src/androidTest/java/tech/relaycorp/courier/ui/settings/SettingsActivityTest.kt
+++ b/app/src/androidTest/java/tech/relaycorp/courier/ui/settings/SettingsActivityTest.kt
@@ -1,5 +1,6 @@
 package tech.relaycorp.courier.ui.settings
 
+import androidx.test.espresso.Espresso.onIdle
 import com.google.android.material.slider.Slider
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertDisabled
 import com.adevinta.android.barista.assertion.BaristaEnabledAssertions.assertEnabled
@@ -7,6 +8,9 @@ import com.adevinta.android.barista.assertion.BaristaVisibilityAssertions.assert
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -51,11 +55,11 @@ class SettingsActivityTest {
     }
 
     @Test
-    fun clearButtonDisabledWithData() {
-        runBlocking {
-            storedMessageDao.insert(StoredMessageFactory.build())
-        }
+    fun clearButtonDisabledWithData() = runTest(StandardTestDispatcher()) {
+        storedMessageDao.insert(StoredMessageFactory.build())
+        advanceUntilIdle()
         testRule.start()
+        onIdle()
         assertEnabled(R.id.deleteData)
     }
 


### PR DESCRIPTION
updated: Kotlin compiler args 
added: extra synchronization on clearButtonDisabledWithData

closes: #527 